### PR TITLE
chore: improve middleware combiner return types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-handler-middleware",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "dist/index.js",
   "repository": "https://github.com/RexfordEssilfie/nextjs-handler-middleware",
   "scripts": {

--- a/src/combine.ts
+++ b/src/combine.ts
@@ -19,9 +19,8 @@ export const mergeMiddleware =
     handler: Handler<
       MergedNextApiRequest<inferMiddlewareReq<A>, inferMiddlewareReq<B>>
     >
-  ) => {
-    return a(b(handler as Handler));
-  };
+  ): typeof handler =>
+    a(b(handler));
 
 /**
  * Merges two Next.js API middleware into one (middleware applied from last to first)
@@ -29,16 +28,15 @@ export const mergeMiddleware =
  * @returns
  */
 export const stackMiddleware = <M1 extends AnyMiddleware>(middlewareA: M1) => {
-  const newHandler = (handler: inferMiddlewareHandler<M1>) => {
-    return middlewareA(handler);
-  };
+  const stackedMiddleware = (
+    handler: inferMiddlewareHandler<M1>
+  ): typeof handler => middlewareA(handler);
 
-  newHandler.kind = "stack" as "stack";
-
-  newHandler.add = <M2 extends Middleware>(middlewareB: M2) =>
+  stackedMiddleware.kind = "stack" as "stack";
+  stackedMiddleware.add = <M2 extends AnyMiddleware>(middlewareB: M2) =>
     stackMiddleware(mergeMiddleware(middlewareA, middlewareB));
 
-  return newHandler;
+  return stackedMiddleware;
 };
 
 /**
@@ -47,14 +45,13 @@ export const stackMiddleware = <M1 extends AnyMiddleware>(middlewareA: M1) => {
  * @returns
  */
 export const chainMiddleware = <M1 extends AnyMiddleware>(middlewareA: M1) => {
-  const newHandler = (handler: inferMiddlewareHandler<M1>) => {
-    return middlewareA(handler);
-  };
+  const chainedMiddleware = (
+    handler: inferMiddlewareHandler<M1>
+  ): typeof handler => middlewareA(handler);
 
-  newHandler.kind = "chain" as "chain";
-
-  newHandler.add = <M2 extends AnyMiddleware>(middlewareB: M2) =>
+  chainedMiddleware.kind = "chain" as "chain";
+  chainedMiddleware.add = <M2 extends AnyMiddleware>(middlewareB: M2) =>
     chainMiddleware(mergeMiddleware(middlewareB, middlewareA));
 
-  return newHandler;
+  return chainedMiddleware;
 };

--- a/src/create.ts
+++ b/src/create.ts
@@ -1,8 +1,8 @@
 import { NextApiResponse } from "next";
 import {
-  Callback,
+  CreateMiddlewareCb,
   Handler,
-  inferCallbackReq,
+  inferCreateMiddlewareCbReq,
   ExtendedNextApiRequest,
 } from "./types";
 
@@ -23,7 +23,7 @@ export function createMiddleware<
     Partial<MReqParams> | MReqParams
   > = ExtendedNextApiRequest<Partial<MReqParams>>,
   MRes extends NextApiResponse<MResBody> = NextApiResponse<MResBody>
->(callback: Callback<MReq & Partial<MReqDeps>, MRes>) {
+>(callback: CreateMiddlewareCb<MReq & Partial<MReqDeps>, MRes>) {
   return function middleware(handler: Handler<MReq>): typeof handler {
     return async function middlewareHandler(req, res) {
       const next = () => handler(req, res);
@@ -31,7 +31,7 @@ export function createMiddleware<
       // Run the callback. Cast req to the type of callback's req
       // since we assume deps are already attached to the request
       return await callback(
-        req as inferCallbackReq<typeof callback>,
+        req as inferCreateMiddlewareCbReq<typeof callback>,
         res as MRes,
         next
       );

--- a/src/create.ts
+++ b/src/create.ts
@@ -16,25 +16,23 @@ import {
  *  and returns the newly wrapped handler
  */
 export function createMiddleware<
-  WReqParams extends Record<string, any> = {},
-  WResBody = unknown,
-  WReqDeps extends Record<string, any> = {},
-  WReq extends ExtendedNextApiRequest<
-    Partial<WReqParams> | WReqParams
-  > = ExtendedNextApiRequest<Partial<WReqParams>>,
-  WRes extends NextApiResponse<WResBody> = NextApiResponse<WResBody>
->(callback: Callback<WReq & Partial<WReqDeps>, WRes>) {
-  return function middleware(handler: Handler<WReq>): typeof handler {
+  MReqParams extends Record<string, any> = {},
+  MResBody = unknown,
+  MReqDeps extends Record<string, any> = {},
+  MReq extends ExtendedNextApiRequest<
+    Partial<MReqParams> | MReqParams
+  > = ExtendedNextApiRequest<Partial<MReqParams>>,
+  MRes extends NextApiResponse<MResBody> = NextApiResponse<MResBody>
+>(callback: Callback<MReq & Partial<MReqDeps>, MRes>) {
+  return function middleware(handler: Handler<MReq>): typeof handler {
     return async function middlewareHandler(req, res) {
-      function next() {
-        return handler(req, res);
-      }
+      const next = () => handler(req, res);
 
       // Run the callback. Cast req to the type of callback's req
       // since we assume deps are already attached to the request
       return await callback(
         req as inferCallbackReq<typeof callback>,
-        res as WRes,
+        res as MRes,
         next
       );
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export type inferMiddlewareReq<M extends Middleware<any>> = Parameters<
 /**
  * The middleware callback type.
  */
-export type Callback<
+export type CreateMiddlewareCb<
   Req extends NextApiRequest = NextApiRequest & Record<string, any>,
   Res extends NextApiResponse = NextApiResponse<any>
 > = (req: Req, res: Res, next: Function) => ReturnType<NextApiHandler>;
@@ -33,8 +33,8 @@ export type Callback<
 /**
  * Helper type to infer the callback's request type
  */
-export type inferCallbackReq<
-  C extends Callback<Req, Res>,
+export type inferCreateMiddlewareCbReq<
+  C extends CreateMiddlewareCb<Req, Res>,
   Req extends NextApiRequest = any,
   Res extends NextApiResponse = any
 > = Parameters<C>[0];


### PR DESCRIPTION
# Overview
This PR drills the type of a combiner's middleware handler through to the return type of the combined middleware, making them more specific than the generic `AnyHandler` and allowing for deeper type inference.
It also renames some internal variables of `stackedMiddleware` and `chainedMiddleware` to make them more meaningful.

# Screenshots
Before
<img width="769" alt="Screenshot 2023-02-20 at 01 17 57" src="https://user-images.githubusercontent.com/43508242/220038584-42bb5dab-f1dd-4d5d-8ba6-7dfb0a27b8f2.png">

After
<img width="705" alt="Screenshot 2023-02-20 at 01 18 22" src="https://user-images.githubusercontent.com/43508242/220038598-0b0350dd-0255-4ef1-bf7a-266752f247b4.png">


