### PR TITLE
feat: add create handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The middleware will be applied as follows:
 middlewareB(middlewareA(handler))
 ```
 
-## Middleware + Zod Request Validation
+## `createMiddleware` + `zod` Request Validation
 In addition to the examples above, you can also perform request validation using the middleware, and
 then have strong type definitions for the request body for post requests.
 
@@ -231,6 +231,33 @@ const middleware = protectedMiddleware.add(validateBodyMiddleware(schema));
 export default middleware(async function handler (req, res) {
     res.status(200).send({ message: `hello ${req.body.name}` }); // req.body is defined and strongly typed by middleware
   });
+```
+
+## `createHandler`
+The `createHandler` function can be used to create a NextJS API handler with specific handlers for each request method. It supports a `middleware` configuration option that let's you specify middleware to be executed for each request method.
+
+### Usage: `createHandler` + Protected and Public Routes per Method
+```ts
+// pages/api/hello.ts
+import { createHandler } from "nextjs-handler-middleware";
+import { protectedMiddleware, publicMiddleware } from "../../lib/middleware";
+
+const handler = createHandler({
+  middleware: {
+    get: publicMiddleware,
+    post: protectedMiddleware,
+  },
+})
+
+handler.get((req, res) => {
+  res.status(200).send({ message: `Hello from public route!` });
+})
+
+handler.post((req, res) => {
+  res.status(200).send({ message: `Hello from protected route!`, user: req.user });
+})
+
+export default handler;
 ```
 
 ## Directly Invoking Middleware

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-handler-middleware",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "repository": "https://github.com/RexfordEssilfie/nextjs-handler-middleware",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-handler-middleware",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "repository": "https://github.com/RexfordEssilfie/nextjs-handler-middleware",
   "scripts": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,15 @@
+// Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+/**
+ * List of http methods.
+ */
+export const HTTP_METHODS = {
+  GET: "GET",
+  POST: "POST",
+  PUT: "PUT",
+  PATCH: "PATCH",
+  DELETE: "DELETE",
+  HEAD: "HEAD",
+  OPTIONS: "OPTIONS",
+  TRACE: "TRACE",
+  CONNECT: "CONNECT",
+} as const;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,0 +1,106 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { HTTP_METHODS } from "./constants";
+import {
+  AnyHandler,
+  AnyMiddleware,
+  CreateHandlerConfig,
+  GenericHandler,
+  inferCreateHandlerConfig,
+  inferMiddlewareHandler,
+} from "./types";
+
+export const createHandler = <
+  Config extends CreateHandlerConfig = CreateHandlerConfig
+>(
+  config?: Config
+) => {
+  let _post: AnyHandler;
+  let _get: AnyHandler;
+  let _patch: AnyHandler;
+  let _put: AnyHandler;
+  let _delete: AnyHandler;
+
+  const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+    const methodMap = {
+      [HTTP_METHODS.POST]: _post,
+      [HTTP_METHODS.PUT]: _put,
+      [HTTP_METHODS.PATCH]: _patch,
+      [HTTP_METHODS.DELETE]: _delete,
+      [HTTP_METHODS.GET]: _get,
+    };
+
+    const method = req.method?.toUpperCase();
+
+    if (!method) {
+      res.status(500).json({ message: "Missing request method!" });
+      return;
+    }
+
+    const methodHandler = methodMap[method as keyof typeof methodMap];
+
+    if (!methodHandler) {
+      res.status(405).json({ message: "Unsupported method!" });
+      return;
+    }
+
+    methodHandler(req, res);
+  };
+
+  // Register post handler
+  handler.post = <Req = NextApiRequest, Res = NextApiResponse>(
+    h: inferCreateHandlerConfig<Config, "post"> extends AnyMiddleware
+      ? inferMiddlewareHandler<inferCreateHandlerConfig<Config, "post">>
+      : GenericHandler<Req, Res>
+  ) => {
+    const middleware = config?.middleware?.post || config?.middleware?.default;
+    _post = middleware ? middleware(h) : h;
+    return handler;
+  };
+
+  // Register get handler
+  handler.get = <Req = NextApiRequest, Res = NextApiResponse>(
+    h: inferCreateHandlerConfig<Config, "get"> extends AnyMiddleware
+      ? inferMiddlewareHandler<inferCreateHandlerConfig<Config, "get">>
+      : GenericHandler<Req, Res>
+  ) => {
+    const middleware = config?.middleware?.get || config?.middleware?.default;
+    _get = middleware ? middleware(h) : h;
+    return handler;
+  };
+
+  // Register patch handler
+  handler.patch = <Req = NextApiRequest, Res = NextApiResponse>(
+    h: inferCreateHandlerConfig<Config, "patch"> extends AnyMiddleware
+      ? inferMiddlewareHandler<inferCreateHandlerConfig<Config, "patch">>
+      : GenericHandler<Req, Res>
+  ) => {
+    const middleware = config?.middleware?.patch || config?.middleware?.default;
+    _patch = middleware ? middleware(h) : h;
+    return handler;
+  };
+
+  // Register put handler
+  handler.put = <Req = NextApiRequest, Res = NextApiResponse>(
+    h: inferCreateHandlerConfig<Config, "put"> extends AnyMiddleware
+      ? inferMiddlewareHandler<inferCreateHandlerConfig<Config, "put">>
+      : GenericHandler<Req, Res>
+  ) => {
+    const middleware = config?.middleware?.put || config?.middleware?.default;
+    _put = middleware ? middleware(h) : h;
+    return handler;
+  };
+
+  // Register delete handler
+  handler.delete = <Req = NextApiRequest, Res = NextApiResponse>(
+    h: inferCreateHandlerConfig<Config, "delete"> extends AnyMiddleware
+      ? inferMiddlewareHandler<inferCreateHandlerConfig<Config, "delete">>
+      : GenericHandler<Req, Res>
+  ) => {
+    const middleware =
+      config?.middleware?.delete || config?.middleware?.default;
+    _delete = middleware ? middleware(h) : h;
+    return handler;
+  };
+
+  return handler;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./combine";
 export * from "./create";
+export * from "./handler";

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,3 +66,45 @@ export type MergedNextApiRequest<
 > = MergeLeft<ReqA, ReqB> extends NextApiRequest
   ? MergeLeft<ReqA, ReqB>
   : never;
+
+/**
+ * A generic handler that does not enforce request or response types
+ * for flexible use cases in createHandlerWithMiddleware.
+ */
+export type GenericHandler<Req, Res> = (
+  req: Req,
+  res: Res
+) => ReturnType<NextApiHandler>;
+
+/**
+ * The keys of the middleware config object.
+ */
+export type CreateHandlerMiddlewareKeys =
+  | "get"
+  | "post"
+  | "put"
+  | "patch"
+  | "delete"
+  | "default";
+
+/**
+ * The type of the config object passed to the createHandler function.
+ */
+export type CreateHandlerConfig = {
+  middleware?: Partial<Record<CreateHandlerMiddlewareKeys, AnyMiddleware>>;
+};
+
+/**
+ * Infers the middleware type from the config. Checks for the specified method
+ * then defaults to the type of the default middleware, otherwise returns undefined.
+ */
+export type inferCreateHandlerConfig<
+  C extends CreateHandlerConfig,
+  K extends CreateHandlerMiddlewareKeys
+> = C["middleware"] extends Record<string, AnyMiddleware>
+  ? C["middleware"][K] extends AnyMiddleware
+    ? C["middleware"][K]
+    : C["middleware"]["default"] extends AnyMiddleware
+    ? C["middleware"]["default"]
+    : undefined
+  : undefined;

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -1,0 +1,172 @@
+import test from "ava";
+import { createHandler } from "../src/handler";
+import { createMocks } from "node-mocks-http";
+import { createMiddleware } from "../src/create";
+
+test("createHandler - runs GET method with middleware", async (t) => {
+  const { req, res } = createMocks({
+    method: "GET",
+  });
+
+  const middleware = createMiddleware<{ foo: "bar" | "baz" }>(
+    (req, res, next) => {
+      req.foo = "bar";
+      next();
+    }
+  );
+
+  const handler = createHandler({
+    middleware: {
+      get: middleware,
+    },
+  });
+
+  handler.get(async (req, res) => {
+    res.status(200).send(req.foo);
+  });
+
+  handler(req, res);
+
+  t.is(res._getStatusCode(), 200);
+  t.is(res._getData(), req.foo);
+});
+
+test("createHandler - runs POST method", async (t) => {
+  const { req, res } = createMocks({
+    method: "POST",
+  });
+
+  const middleware = createMiddleware<{ foo: "bar" | "baz" }>(
+    (req, res, next) => {
+      req.foo = "bar";
+      next();
+    }
+  );
+
+  const handler = createHandler({
+    middleware: {
+      post: middleware,
+    },
+  });
+
+  handler.post(async (req, res) => {
+    res.status(200).send(req.foo);
+  });
+
+  handler(req, res);
+
+  t.is(res._getStatusCode(), 200);
+  t.is(res._getData(), req.foo);
+});
+
+test("createHandler - runs PUT method", async (t) => {
+  const { req, res } = createMocks({
+    method: "PUT",
+  });
+
+  const middleware = createMiddleware<{ foo: "bar" | "baz" }>(
+    (req, res, next) => {
+      req.foo = "bar";
+      next();
+    }
+  );
+
+  const handler = createHandler({
+    middleware: {
+      put: middleware,
+    },
+  });
+
+  handler.put(async (req, res) => {
+    res.status(200).send(req.foo);
+  });
+
+  handler(req, res);
+
+  t.is(res._getStatusCode(), 200);
+  t.is(res._getData(), req.foo);
+});
+
+test("createHandler - runs PATCH method", async (t) => {
+  const { req, res } = createMocks({
+    method: "PATCH",
+  });
+
+  const middleware = createMiddleware<{ foo: "bar" | "baz" }>(
+    (req, res, next) => {
+      req.foo = "bar";
+      next();
+    }
+  );
+
+  const handler = createHandler({
+    middleware: {
+      patch: middleware,
+    },
+  });
+
+  handler.patch(async (req, res) => {
+    res.status(200).send(req.foo);
+  });
+
+  handler(req, res);
+
+  t.is(res._getStatusCode(), 200);
+  t.is(res._getData(), req.foo);
+});
+
+test("createHandler - runs DELETE method", async (t) => {
+  const { req, res } = createMocks({
+    method: "DELETE",
+  });
+
+  const middleware = createMiddleware<{ foo: "bar" | "baz" }>(
+    (req, res, next) => {
+      req.foo = "bar";
+      next();
+    }
+  );
+
+  const handler = createHandler({
+    middleware: {
+      delete: middleware,
+    },
+  });
+
+  handler.delete(async (req, res) => {
+    res.status(200).send(req.foo);
+  });
+
+  handler(req, res);
+
+  t.is(res._getStatusCode(), 200);
+  t.is(res._getData(), req.foo);
+});
+
+test("createHandler - executes handler with default middleware", async (t) => {
+  const { req, res } = createMocks({
+    method: "GET",
+  });
+
+  const middleware = createMiddleware<{ foo: "bar" | "baz" }>(
+    (req, res, next) => {
+      req.foo = "bar";
+      next();
+    }
+  );
+
+  const handler = createHandler({
+    middleware: {
+      default: middleware,
+    },
+  });
+
+  handler.get(async (req, res) => {
+    res.status(200).send(req.foo);
+  });
+
+  handler(req, res);
+
+  t.is(res._getStatusCode(), 200);
+  t.is(res._getData(), "bar");
+});


### PR DESCRIPTION
# Overview
This PR adds a `createHandler` function to the repository! This kind of pattern is useful for the common case of having to distinguish between the request method type in NextJS's handler. It is also augmented with a `middleware` config that allows for adding middleware created with `createMiddleware` and having type inference directly where the request types are used in the method handler.

# Usage
```typescript
// pages/api/hello.ts
const middlewareA = createMiddleware<{ foo: "bar" | "baz" }>(
  (req, res, next) => {
    req.foo = "bar";
    next();
  }
);

const middlewareB = createMiddleware<{ pet: "cat" | "dog" }>(
  (req, res, next) => {
    req.pet = "cat";
    next();
  }
);

const handler = createHandler({
  middleware: {
    get: middlewareA,
    post: middlewareB,
  },
});

handler.get(async (req, res) => {
  res.status(200).send(req.foo); // strongly typed
});

handler.post(async (req, res) => {
  res.status(200).send(req.pet); // strongly typed
});

export default handler;
```
